### PR TITLE
Popup elements in Firefox have strange offsets

### DIFF
--- a/app/modules/transcribe/overlay/context-menu.directive.js
+++ b/app/modules/transcribe/overlay/context-menu.directive.js
@@ -1,7 +1,5 @@
 'use strict';
 
-var reactivateMarkingSurface;
-var _ = require('lodash');
 var angular = require('angular');
 var Hammer = require('hammerjs');
 
@@ -64,6 +62,7 @@ function contextMenuController($rootScope, $scope, $timeout, MarkingSurfaceFacto
 
     // Setup
     var vm = this;
+    var reactivateMarkingSurface;
     vm.close = closeMenu;
     vm.open = openMenu;
 
@@ -93,18 +92,10 @@ function contextMenuController($rootScope, $scope, $timeout, MarkingSurfaceFacto
     }
 
     function _positionMenu(data) {
-        var click = data.event.srcEvent;
+        var click = data.event.center;
         vm.position = {
-            left: click.offsetX,
-            top: click.offsetY
+            left: click.x,
+            top: click.y - MarkingSurfaceFactory.svg[0].getBoundingClientRect().top
         };
-
-        // Firefox doesn't support offset, so we need to polyfill here.
-        if (_.isUndefined(click.offsetX) || _.isUndefined(click.offsetY)) {
-            vm.position = {
-                left: click.pageX - overlay.offset().left,
-                top: click.pageY - overlay.offset().top
-            };
-        }
     }
 }

--- a/app/styles/components/alphabet-sample.styl
+++ b/app/styles/components/alphabet-sample.styl
@@ -3,10 +3,11 @@
     @extend .panel-default
     background-color: rgba(245, 245, 245, 0.5)
     display: none
+    height: 100%
     position: absolute
     right: 0
+    top: 0
     width: 30%
-    height: 100%
     z-index: 1
 
 


### PR DESCRIPTION
Minor UI Issue:
* Popup elements in Firefox do not always appear in their intended positions.
* Notably: the "Alphabets Guide" popup (from clicking the "A" button on the right-hand side toolbox) appears far lower than it should be.
* Also, the "Edit/Delete" popup menu (from clicking an existing Type or Graphic overlay indicator) appears in the upper-left corner of the window instead of near where the click event occurred.

![zooniverse-20151110-folgerdemo-ff](https://cloud.githubusercontent.com/assets/13952701/11066296/8a0bc0e4-87bf-11e5-812a-20b179985a50.png)
_Above: Chrome, Below: Firefox_

Potentially Related Issue:
* "Transcribe Text" tool marker moves like a yo-yo in Firefox - https://github.com/zooniverse/shakespeares_world/issues/141

Hypothesis:
* This is an issue specific to Firefox x-y offsets.
* Possibly, there is confusion in detecting the parent elements' x-y offsets, etc.

Tested On:
* Firefox 42 / Win 10 - Issue confirmed.
* Chrome 46 / Win 10 - No issue.
* Opera 33 / Win 10 - No issue.