### PR TITLE
Graphic and crop tool creates duplicate element

### DIFF
--- a/app/modules/transcribe/marking-tools/graphic.factory.js
+++ b/app/modules/transcribe/marking-tools/graphic.factory.js
@@ -95,6 +95,8 @@ function graphicTool($rootScope, $timeout, AnnotationsFactory, MarkingSurfaceFac
 
     function _endRect() {
         _hammer.off('panmove', _drawRect);
+        _hammer.off('panend', _endRect);
+
         AnnotationsFactory.upsert({
             type: 'graphic',
             x: _rect.attr('x'),


### PR DESCRIPTION
To reproduce:

1. Draw a rectangle
2. Select and save or close the dialog
3. Draw a second rectangle
4. Inspect Local Storage in the browser's console
5. The json blob will show a duplicate object with 0x0 dimensions and the tag property.

Example below with `type: graphic`

```json
[
    {
        "type": "graphic",
        "x": "114.7",
        "y": "503.71",
        "width": "49.749999999999986",
        "height": "46.64000000000004",
        "tag": "<graphic>manicule<graphic/>"
    },
    {
        "type": "graphic",
        "x": "307.47",
        "y": "603.21",
        "width": "40.41999999999996",
        "height": "40.41999999999996"
    },
    {
        "type": "graphic",
        "x": "307.47",
        "y": "603.21",
        "width": "0",
        "height": "0",
        "tag": "<graphic>symbol<graphic/>"
    }
]
```


This also happens with AnnoTate image tool.