### PR TITLE
Fixed Flex issues on IE11 for About page, Guide page.

### DIFF
--- a/app/styles/components/about-content.styl
+++ b/app/styles/components/about-content.styl
@@ -3,7 +3,7 @@
     background-repeat: no-repeat
     background-size: cover
     background-position: center
-    flex: 1
+    flex: 1 0 auto
 
     > .content
         @extend .container

--- a/app/styles/components/guide-page.styl
+++ b/app/styles/components/guide-page.styl
@@ -1,6 +1,6 @@
 .guide-page
     background-color: offwhite
-    flex: 1
+    flex: 1 0 auto
 
     dl > dt
         margin-top: 24px


### PR DESCRIPTION
For the two pages, changed flex:1 to flex:1 0 auto, which prevents container
from shrinking to accommodate the header and footer.

This is the same fix as #160.

WARNING: Team page is still wonky as all heck, as it follows different style conventions. This is still being investingated.
WARNING: Fixing Team page for IE may conflict with any ongoing fixes for Team page for Firefox; please be aware.