### PR TITLE
New odd site behavior

### DIFF
--- a/app/modules/auth/auth.factory.js
+++ b/app/modules/auth/auth.factory.js
@@ -83,14 +83,15 @@ function authFactory($interval, $location, $window, localStorageService, ModalsF
     }
 
     function signIn() {
-        localStorageService.set('redirectOnSignIn', $location.absUrl());
+        var urlBase = $location.absUrl().replace('https:', 'http:');
+        localStorageService.set('redirectOnSignIn', urlBase);
         $window.location.href = zooAPI.root.match(/^(.*)\/[^/]*$/)[1] +
             '/oauth/authorize' +
             '?response_type=token' +
             '&client_id=' +
             zooAPIConfig.app_id +
             '&redirect_uri=' +
-            $location.absUrl().match(/.+?(?=\#\/)/)[0];
+            urlBase.match(/.+?(?=\#\/)/)[0];
     }
 
     function signOut() {


### PR DESCRIPTION
https://www.zooniverse.org/projects/zooniverse/shakespeares-world/talk/194/22612?comment=47112

The user writes: 'It must be something specific to me, since I haven't seen anyone having this (these?) issue(s):' [But, given there were some fixes yesterday, maybe this is new?]

http://www.shakespearesworld.org takes me to a grey screen, with nothing on it.
https://www.shakespearesworld.org gives me a cert error (cert belongs to *.zooniverse.com). If I click through the security warnings, I can get to the page.
Adding /#/Transcribe to the end of the URL does work (thanks to whoever posted that), in that I can see and transcribe pages, BUT:
If I click "Sign in through Zooniverse" it takes me to the Zooniverse login page, where I can authenticate successfully, but then it gives me an error when it tries to take me back: "An error has occurred/The redirect uri included is not valid." (I'll paste the URI below.)
I've tried editing the redirect_uri a few different ways but none of them seem to work.
If I open Shakespeare's World in another tab in the same browser, it does not seem to recognize that I've logged in, but if I click "Sign in through Zooniverse" again, it takes me immediately back to the failed redirect_uri error, without asking me to authenticate again, so I assume that part is all working fine.
This is all using Chrome, but I've had at least some of the same symptoms in Firefox and IE.
https://panoptes.zooniverse.org/oauth/authorize?response_type=token&client_id=2abed6ac014d4a8416a1f578de922600451a10c759dfeab6c9f0edbeb91c8f88&redirect_uri=https://www.shakespearesworld.org/

