### PR TITLE
Base64 encode variants file names

### DIFF
--- a/scripts/create_variants_files.rb
+++ b/scripts/create_variants_files.rb
@@ -1,4 +1,5 @@
 #!/usr/bin/env ruby
+require 'base64'
 require 'csv'
 require 'pry'
 require 'aws-sdk'
@@ -36,7 +37,7 @@ variants.each_with_index do |(key, data), index|
   puts "Up to entry: #{index}" if index % 1000 == 0
 
   ##create a file for use with s3 cli sync tool
-  file_path = "#{OUTPUT_DIR}/#{key}.txt"
+  file_path = "#{OUTPUT_DIR}/#{Base64.urlsafe_encode64(key)}.txt"
   dirname = File.dirname(file_path)
   unless File.directory?(dirname)
     FileUtils.mkdir_p(dirname)


### PR DESCRIPTION
There are files with unicode characters in their names at the moment, so this should avoid any potential problems with accessing them.

I haven't generated new files yet. I'll do that after this is merged. Then after that we'll need to update the logic in [annotations.factory.js](https://github.com/zooniverse/shakespeares_world/blob/variants-update/app/modules/transcribe/annotations/annotations.factory.js#L74) to match.