### PR TITLE
Stop gap fix for subject selection

### DIFF
--- a/app/modules/transcribe/subjects.factory.js
+++ b/app/modules/transcribe/subjects.factory.js
@@ -123,7 +123,6 @@ function SubjectsFactory($q, AnnotationsFactory, localStorageService, zooAPI, zo
     function _populateQueue() {
         return zooAPIProject.get()
             .then(function (project) {
-                console.log('_.sample(project.links.subject_sets)', project.links.subject_sets)
                 return zooAPI.get('/subjects/queued', {
                     workflow_id: zooAPIConfig.workflow_id,
                     // Get a random set if one isn't specified already

--- a/app/modules/transcribe/subjects.factory.js
+++ b/app/modules/transcribe/subjects.factory.js
@@ -123,10 +123,11 @@ function SubjectsFactory($q, AnnotationsFactory, localStorageService, zooAPI, zo
     function _populateQueue() {
         return zooAPIProject.get()
             .then(function (project) {
+                console.log('_.sample(project.links.subject_sets)', project.links.subject_sets)
                 return zooAPI.get('/subjects/queued', {
                     workflow_id: zooAPIConfig.workflow_id,
                     // Get a random set if one isn't specified already
-                    subject_set_id: (_subjectSet) ? _subjectSet : _.sample(project.links.subject_sets)
+                    subject_set_id: (_subjectSet) ? _subjectSet : _.sample(['2778', '2776'])
                 });
             })
             .then(function (subjects) {


### PR DESCRIPTION
Fix #353. It follows up from a conversation on Slack with @camallen, who spotted the bug in the code. This quick fix hardcodes the IDs of subjects sets associate with the current workflow. That will have to be removed, in favour of getting the associated sets from the active workflow.