### PR TITLE
Better subject selection

### DIFF
--- a/app/modules/transcribe/subjects.factory.js
+++ b/app/modules/transcribe/subjects.factory.js
@@ -39,7 +39,8 @@ function SubjectsFactory($q, AnnotationsFactory, localStorageService, zooAPI, zo
             _updateStorage();
         }
         if (!_queue.length) {
-            return _populateQueue()
+            return  _getSubjectSetId()
+                .then(_populateQueue)
                 .then(_setCurrent);
         } else {
             return $q.when(_setCurrent());
@@ -109,6 +110,17 @@ function SubjectsFactory($q, AnnotationsFactory, localStorageService, zooAPI, zo
         });
     }
 
+    function _getRandomWorkflowAssociatedSubjectSets() {
+        return zooAPI.type('workflows').get(zooAPIConfig.workflow_id)
+            .then(function(wf) {
+                var randomSet = _.sample(wf.links.subject_sets)
+                return randomSet
+            })
+            .catch(function(error) {
+                console.log('Error fetching active subject sets', error)
+            })
+    }
+
     function _loadImage() {
         var deferred = $q.defer();
         factory.current.image = new Image();
@@ -120,13 +132,13 @@ function SubjectsFactory($q, AnnotationsFactory, localStorageService, zooAPI, zo
         return deferred.promise;
     }
 
-    function _populateQueue() {
+    function _populateQueue(subjectSetId) {
         return zooAPIProject.get()
             .then(function (project) {
                 return zooAPI.get('/subjects/queued', {
                     workflow_id: zooAPIConfig.workflow_id,
                     // Get a random set if one isn't specified already
-                    subject_set_id: (_subjectSet) ? _subjectSet : _.sample(['2778', '2776'])
+                    subject_set_id: subjectSetId
                 });
             })
             .then(function (subjects) {

--- a/app/modules/transcribe/subjects.factory.js
+++ b/app/modules/transcribe/subjects.factory.js
@@ -96,7 +96,6 @@ function SubjectsFactory($q, AnnotationsFactory, localStorageService, zooAPI, zo
 
     function _getSubjectSetId() {
         if (_subjectSet) {
-          console.log('_subjectSet', _subjectSet)
           return Promise.resolve(_subjectSet);
         } else {
           return _getRandomWorkflowAssociatedSubjectSets()
@@ -123,7 +122,6 @@ function SubjectsFactory($q, AnnotationsFactory, localStorageService, zooAPI, zo
         return zooAPI.type('workflows').get(zooAPIConfig.workflow_id)
             .then(function(wf) {
                 var randomSet = _.sample(wf.links.subject_sets)
-                console.log('random set', randomSet)
                 return randomSet
             })
             .catch(function(error) {

--- a/app/modules/transcribe/subjects.factory.js
+++ b/app/modules/transcribe/subjects.factory.js
@@ -94,6 +94,15 @@ function SubjectsFactory($q, AnnotationsFactory, localStorageService, zooAPI, zo
         }
     }
 
+    function _getSubjectSetId() {
+        if (_subjectSet) {
+          console.log('_subjectSet', _subjectSet)
+          return Promise.resolve(_subjectSet);
+        } else {
+          return _getRandomWorkflowAssociatedSubjectSets()
+        }
+      }
+
     function _isAnnotatedSubjectEqualToCurrent() {
         var found = false;
         _annotations.forEach(function(element) {
@@ -114,6 +123,7 @@ function SubjectsFactory($q, AnnotationsFactory, localStorageService, zooAPI, zo
         return zooAPI.type('workflows').get(zooAPIConfig.workflow_id)
             .then(function(wf) {
                 var randomSet = _.sample(wf.links.subject_sets)
+                console.log('random set', randomSet)
                 return randomSet
             })
             .catch(function(error) {


### PR DESCRIPTION
Gets a random subject set from the subject sets linked to the current workflow. This ensures subjects are only served from subject sets associated with that workflow. 
Can be tested at https://preview.zooniverse.org/shakespearesworld/#!/