### PR TITLE
Remove target=_blank from the main navigation.

### DIFF
--- a/app/modules/layout/header/header.html
+++ b/app/modules/layout/header/header.html
@@ -14,7 +14,7 @@
         <div class="collapse navbar-collapse" collapse="vm.headerCollapse">
             <ul class="nav navbar-nav">
                 <li ng-repeat="link in ::vm.links">
-                    <a ui-sref="{{ link.state }}" ui-sref-active="-active" class="link" ng-bind="link.label"></a>
+                    <a ui-sref="{{ link.state }}" ui-sref-active="-active" class="link" ng-bind="link.label" target="sw"></a>
                 </li>
                 <li><a class="link" href="https://www.zooniverse.org/projects/zooniverse/shakespeares-world/talk/" target="swtalk">Talk</a></li>
                 <li>

--- a/app/modules/layout/header/header.html
+++ b/app/modules/layout/header/header.html
@@ -16,9 +16,9 @@
                 <li ng-repeat="link in ::vm.links">
                     <a ui-sref="{{ link.state }}" ui-sref-active="-active" class="link" ng-bind="link.label"></a>
                 </li>
-                <li><a class="link" href="https://www.zooniverse.org/projects/zooniverse/shakespeares-world/talk/" target="_blank">Talk</a></li>
+                <li><a class="link" href="https://www.zooniverse.org/projects/zooniverse/shakespeares-world/talk/" target="swtalk">Talk</a></li>
                 <li>
-                    <a class="link" href="http://blog.shakespearesworld.org/" target="_blank">Blog</a>
+                    <a class="link" href="http://blog.shakespearesworld.org/" target="swblog">Blog</a>
                 </li>
             </ul>
             <div auth-header></div>

--- a/app/modules/layout/header/header.html
+++ b/app/modules/layout/header/header.html
@@ -14,7 +14,7 @@
         <div class="collapse navbar-collapse" collapse="vm.headerCollapse">
             <ul class="nav navbar-nav">
                 <li ng-repeat="link in ::vm.links">
-                    <a ui-sref="{{ link.state }}" ui-sref-active="-active" class="link" ng-bind="link.label" target="_blank"></a>
+                    <a ui-sref="{{ link.state }}" ui-sref-active="-active" class="link" ng-bind="link.label"></a>
                 </li>
                 <li><a class="link" href="https://www.zooniverse.org/projects/zooniverse/shakespeares-world/talk/" target="_blank">Talk</a></li>
                 <li>


### PR DESCRIPTION
Links should [only open in new windows or tabs when necessary](https://www.w3.org/TR/WCAG20-TECHS/G200.html). This PR changes internal links to open in the current tab, and external links to reuse the same tab rather than open many new tabs during a browsing session.