### PR TITLE
Update PJC to 2.12.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,7 +90,7 @@
     "nib": "^1.1.0",
     "node-dir": "0.1.16",
     "npm": "^5.3.0",
-    "panoptes-client": "^2.9.4",
+    "panoptes-client": "^2.12.0",
     "pretty-hrtime": "^1.0.3",
     "q": "^1.2.0",
     "run-sequence": "^2.1.0",


### PR DESCRIPTION
## PR Overview
This PR updates the Panoptes JavaScript Client to version 2.12.0, which notably handles the issue where Panoptes is changing `bearer` tokens to `Bearer` tokens. See https://github.com/zooniverse/panoptes-javascript-client/pull/103 for full details.

### Status
I'm going ahead with merging this, then manually deploying it to overcome the odd issue of Shakespeare's World's auto-deploy. Tagging @camallen 